### PR TITLE
The gap option does not work unless the arrowShow option is set to true.

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -383,12 +383,12 @@
 				incr(css, pos, margin);
 			}
 		}
-		gap = Math.max(0, this.options.gap - (this.options.arrowShow ? arrowSize : 0));
+        arrowSize = (this.options.arrowShow ? this.options.arrowSize : 0);
+ 		gap = Math.max(0, this.options.gap - arrowSize);
 		incr(css, oppFull, gap);
 		if (!this.options.arrowShow) {
 			this.arrow.hide();
 		} else {
-			arrowSize = this.options.arrowSize;
 			arrowCss = $.extend({}, css);
 			arrowColor = this.userContainer.css("border-color") || this.userContainer.css("border-top-color") || this.userContainer.css("background-color") || "white";
 			for (k = 0, len1 = mainPositions.length; k < len1; k++) {


### PR DESCRIPTION
The gap option does not work if the arrowShow option set to true in the setElementPosition function. When it is, the gap is calculated using the arrowSize variable, which is not initialized at this point in the function. This change initializes that variable so it works with and without the arrow.