### PR TITLE
return notification instance on creation so we can close it

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -529,12 +529,12 @@
 	$[pluginName] = function(elem, data, options) {
 		if ((elem && elem.nodeName) || elem.jquery) {
 			$(elem)[pluginName](data, options);
+			return elem;
 		} else {
 			options = data;
 			data = elem;
-			new Notification(null, data, options);
+			return new Notification(null, data, options);
 		}
-		return elem;
 	};
 
 	$.fn[pluginName] = function(data, options) {


### PR DESCRIPTION
Example: var loadingNotification = $.notify("Perfoming Update", { clickToHide: true });

$(element).on("update_finished",function() { loadingNotification.trigger("notify-hide"); });